### PR TITLE
add: add setCachedAt on createAccessToken

### DIFF
--- a/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
+++ b/common4j/src/main/com/microsoft/identity/common/java/cache/MicrosoftStsAccountCredentialAdapter.java
@@ -94,6 +94,7 @@ public class MicrosoftStsAccountCredentialAdapter
                             response.getScope()
                     )
             );
+            accessToken.setRequestedClaims(request.getClaims());
             accessToken.setCachedAt(String.valueOf(cachedAt)); // generated @ client side
             accessToken.setExpiresOn(String.valueOf(expiresOn));
             accessToken.setRefreshOn(String.valueOf(refreshOn));


### PR DESCRIPTION
## Problem

- `AccessToken#getClaims()` always return `null`
- logic for add `-<requested_claims>` on `CacheKeyValueDelegate` will not be called

https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/7b1d6f77bd90819282038a57f219a6e874321a94/common4j/src/main/com/microsoft/identity/common/java/cache/CacheKeyValueDelegate.java#L174-L179
